### PR TITLE
Fixed rgb to hex conversion function

### DIFF
--- a/morpheus.js
+++ b/morpheus.js
@@ -40,11 +40,11 @@
           return el.style[camelize(property)];
         },
       rgb = function (r, g, b) {
-        return '#' + (1 << 24 | r << 16 | g << 8 | b).toString(16).substr(1);
+        return '#' + (1 << 24 | r << 16 | g << 8 | b).toString(16).slice(1);
       },
       toHex = function (c) {
         var m = /rgba?\((\d+),\s*(\d+),\s*(\d+)/.exec(c);
-        return (m ? '#' + rgb(m[1], m[2], m[3]) : c)
+        return (m ? rgb(m[1], m[2], m[3]) : c)
         .replace(/#(\w)(\w)(\w)$/, '#$1$1$2$2$3$3'); // short to long
       },
       camelize = function (s) {

--- a/src/morpheus.js
+++ b/src/morpheus.js
@@ -35,11 +35,11 @@
           return el.style[camelize(property)];
         },
       rgb = function (r, g, b) {
-        return '#' + (1 << 24 | r << 16 | g << 8 | b).toString(16).substr(1);
+        return '#' + (1 << 24 | r << 16 | g << 8 | b).toString(16).slice(1);
       },
       toHex = function (c) {
         var m = /rgba?\((\d+),\s*(\d+),\s*(\d+)/.exec(c);
-        return (m ? '#' + rgb(m[1], m[2], m[3]) : c)
+        return (m ? rgb(m[1], m[2], m[3]) : c)
         .replace(/#(\w)(\w)(\w)$/, '#$1$1$2$2$3$3'); // short to long
       },
       camelize = function (s) {


### PR DESCRIPTION
Probably don't want two `#`s, and switched to using `slice` instead of `substr` as suggested by @mathiasbynens (https://twitter.com/mathias/status/71829211794505728) because it is standard and saves a byte.

Btw, I don't know if you want to fix this, but it is a difference from your prior `RGBtoHex` function: negative components and components over 255 shouldn't be accepted.  Didn't add this, but you could if you want! :-)
