### PR TITLE
Removed an extra comma

### DIFF
--- a/src/ender.js
+++ b/src/ender.js
@@ -14,7 +14,7 @@ var morpheus = require('morpheus')
   , fadeOut: function (d, fn) {
       return morpheus(this, {
           duration: d
-        , opacity: 0,
+        , opacity: 0
         , complete: fn
       })
     }


### PR DESCRIPTION
I was just working with morpheus in ender when suddenly uglifyjs started complaining. Turns out there was an extra comma in this file.
