### PR TITLE
rework framing method with proper feature detect

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,17 +1,26 @@
 {
-  "node": true,
-  "asi": true,
-  "laxcomma": true,
-  "boss": true,
-  "browser": true,
-  "eqnull": true,
-  "expr": true,
-  "loopfunc": true,
-  "strict": false,
-  "trailing": true,
-  "undef": true,
-  "smarttabs": true,
-  "supernew": true,
-  "sub": true,
-  "predef": ["define", "require"]
+    "predef": ["assert", "refute", "define", "self"]
+  , "boss": true
+  , "shadow": true
+  , "trailing": true
+  , "latedef": true
+  , "forin": false
+  , "curly": false
+  , "debug": true
+  , "devel": false
+  , "evil": true
+  , "regexp": false
+  , "undef": true
+  , "sub": true
+  , "white": false
+  , "asi": true
+  , "laxbreak": true
+  , "eqnull": true
+  , "browser": true
+  , "node": true
+  , "laxcomma": true
+  , "proto": true
+  , "expr": true
+  , "es5": true
+  , "strict": false
 }

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -26,6 +26,24 @@
     <ol id="tests"></ol>
 
     <script>
+      sink('Basic', function(test, ok, before, after) {
+        var el = document.getElementById('test');
+
+        test('should take roughly the correct duration', 1, function () {
+          var start = +new Date()
+            , duration = 500
+          el.style.width = '10px'
+          morpheus(el, {
+            width: '500px',
+            duration: duration,
+            complete: function () {
+              var delta = +new Date() - start
+              ok(Math.abs(delta - duration) < duration / 10, 'duration is +/- 10% of requested (' + delta + ')')
+            }
+          })
+        })
+      })
+
       sink('Integers', function(test, ok, before, after) {
         var el = document.getElementById('test');
         before(function () {


### PR DESCRIPTION
A.K.A. uber-feature-detect

Further to the discussion @ #36 (/cc @danro)

In summary I've turned `frame(fn)` into a function that takes a render-function and puts it into the animation queue (or makes a queue if required). The function is then called with 2 arguments, (1) is the time-delta from the start of the animation, and (2) a callback that can be used to resubmit the render-function to the same queue.

When first loaded, `frame` will be the most basic version that does `setTimeout` and delta-calculation itself; meanwhile it runs a feature-detect on a `requestAnimationFrame` to see what kind of argument it provides. The alternatives allowed for are (1) standard epoch-`Date`-based timestamp and (2) `performance.now()`-based timestamp. If it finds an `rAF` that works like this, it replaces `frame` with an appropriate `rAF`-based alternative.

This should be pretty future-proof as the fallback should always work. However there may be a need to enhance it in future. e.g. if Mozilla's `animationStartTime` gets traction or if other browsers start using `performance.now()`-based timestamps and vendor-prefix `now` (note though that that won't break this implementation, they'll just fall back to the basic implementation).

I've also imported Bonzo's .jshintrc and I've added a test to ensure that `duration` is roughly obeyed, this should help detect shortcutting.
