### PR TITLE
Fix unit detection for negative values

### DIFF
--- a/src/morpheus.js
+++ b/src/morpheus.js
@@ -13,7 +13,7 @@
     , thousand = 1000
     , rgbOhex = /^rgb\(|#/
     , relVal = /^([+\-])=([\d\.]+)/
-    , numUnit = /^(?:[\+\-]=)?\d+(?:\.\d+)?(%|in|cm|mm|em|ex|pt|pc|px)$/
+    , numUnit = /^(?:[\+\-]=?)?\d+(?:\.\d+)?(%|in|cm|mm|em|ex|pt|pc|px)$/
     , rotate = /rotate\(((?:[+\-]=)?([\-\d\.]+))deg\)/
     , scale = /scale\(((?:[+\-]=)?([\d\.]+))\)/
     , skew = /skew\(((?:[+\-]=)?([\-\d\.]+))deg, ?((?:[+\-]=)?([\-\d\.]+))deg\)/

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -85,6 +85,16 @@
           })
         })
 
+        test('should accept negative value with unit', 1, function () {
+          morpheus(el, {
+            left: '-10%',
+            duration: 10,
+            complete: function () {
+              ok(el.style.left == '-10%', 'el.style.left == "-10%"')
+            }
+          })
+        })
+
         test('should accept positive += offset', 2, function () {
           morpheus(el, {
             top: '+=10px',


### PR DESCRIPTION
The regular expression used to extract the unit (%, em, ...) doesn't work with negative values (and plus-prefixed values, but that's just an edge case).

Adding a `?` after the equal sign allows Morpheus to work correctly when animating to values such as -100%, -50px, -2cm and +150%.

A very common use case is writing carousels / page sliders et similia since we often want to animate left to -100%.
