### PR TITLE
Remove unnecessary break statement

### DIFF
--- a/src/morpheus.js
+++ b/src/morpheus.js
@@ -336,8 +336,7 @@
         case 'duration':
         case 'easing':
         case 'bezier':
-          continue;
-          break
+          continue
         }
         var v = getStyle(els[i], k), unit
           , tmp = fun(options[k]) ? options[k](els[i]) : options[k]


### PR DESCRIPTION
This doesn't seem to make sense:

```
switch (k) {
  case 'complete':
  case 'duration':
  case 'easing':
  case 'bezier':
    continue;
    break
}
```

JSHint seems to agree. While working on another pull request, I got this:

```
- Boo! *./src/morpheus.js* FAILED JSHint with 1 error:
  (error) line 340: Unreachable 'break' after 'continue'.
```
