### PR TITLE
feature detect matching scale of timestamp & now()

### DIFF
--- a/src/morpheus.js
+++ b/src/morpheus.js
@@ -9,6 +9,7 @@
     , perf = win.performance
     , perfNow = perf && (perf.now || perf.webkitNow || perf.msNow || perf.mozNow)
     , now = perfNow ? function () { return perfNow.call(perf) } : function () { return +new Date() }
+    , fixTs = false // feature detected below
     , html = doc.documentElement
     , thousand = 1000
     , rgbOhex = /^rgb\(|#/
@@ -84,6 +85,12 @@
       }
   }()
 
+  frame(function(timestamp) {
+    // feature-detect if rAF and now() are of the same scale (epoch or high-res),
+    // if not, we have to do a timestamp fix on each frame
+    fixTs = timestamp > 1e12 != now() > 1e12
+  })
+
   var children = []
 
   function has(array, elem, i) {
@@ -95,9 +102,7 @@
 
   function render(timestamp) {
     var i, count = children.length
-    // if we're using a high res timer, make sure timestamp is not the old epoch-based value.
-    // http://updates.html5rocks.com/2012/05/requestAnimationFrame-API-now-with-sub-millisecond-precision
-    if (perfNow && timestamp > 1e12) timestamp = now()
+    if (fixTs) timestamp = now()
     for (i = count; i--;) {
       children[i](timestamp)
     }


### PR DESCRIPTION
fixes #53

building on @karlwestin feature-detect for now() vs ts scale (epoch vs highres)
